### PR TITLE
Use defaultConfigWithSandbox so that we pickup $HASKELL_PACKAGE_SANDBOX....

### DIFF
--- a/src/Snap/Snaplet/Fay/Internal.hs
+++ b/src/Snap/Snaplet/Fay/Internal.hs
@@ -7,7 +7,6 @@ import           Control.Applicative
 import           Control.Monad
 import qualified Data.Aeson                 as A
 import qualified Data.ByteString.Lazy.Char8 as C
-import           Data.Default
 import qualified Fay                        as F
 import           System.Directory
 import           System.FilePath
@@ -52,9 +51,10 @@ compileFile config f = do
       return NotFound
     else do
       f' <- canonicalizePath f
+      defConfig <- F.defaultConfigWithSandbox
       res <- flip F.compileFile f' $ F.addConfigPackages (packages config) $
                                       F.addConfigDirectoryIncludePaths (includeDirs config) $
-                                        def { F.configPrettyPrint = prettyPrint config
+                                        defConfig { F.configPrettyPrint = prettyPrint config
                                             , F.configFilePath = Just f'
                                             }
       case res of


### PR DESCRIPTION
...  This fixes issue #7
defaultConfigWithSandbox returns an IO Config so I moved the call to a separate line.
Data.Default is no longer used so I removed it.
I've only tested it on my one OSX machine, if you have concerns I can do more testing.
This is the first time I've created a pull request so please excuse any rookie mistakes.
